### PR TITLE
Fixed options object typings for javascript plugins inside `plugin.d.ts`

### DIFF
--- a/plugin-system/plugin.d.ts
+++ b/plugin-system/plugin.d.ts
@@ -6,8 +6,12 @@ export default interface PluginBaseClass {
     el: HTMLElement;
     $emitter: NativeEventEmitter;
     _pluginName: String;
-    initialOptions: object;
-    options: object;
+    initialOptions: {
+	[key: string]: any;
+    };
+    options: {
+	[key: string]: any;
+    };
     _initialized: boolean;
     init(): void;
     _update(): void;


### PR DESCRIPTION
Solves this issue: https://github.com/shopwareLabs/storefront-types/issues/1