### PR TITLE
feat: add generic to plugin instance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Node 24.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.x'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -23,3 +23,29 @@ To have the types active, you need to create a `tsconfig.json` (`src/Resources/a
     }
 }
 ```
+
+## Typed Plugin Options
+
+You can use a generic type parameter to get fully typed options in your plugins:
+
+```ts
+const { PluginBaseClass } = window;
+
+interface MyPluginOptions {
+    option1: string;
+    option2: number | null;
+}
+
+export default class MyPlugin extends PluginBaseClass<MyPluginOptions> {
+    static options: MyPluginOptions = {
+        option1: 'default value',
+        option2: null
+    };
+
+    init() {
+        // this.options is fully typed
+        console.log(this.options.option1); // string
+        console.log(this.options.option2); // number | null
+    }
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,52 @@
+{
+  "name": "@shopware-ag/storefront-types",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@shopware-ag/storefront-types",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/bootstrap": "^5.2.0"
+      },
+      "devDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@types/bootstrap": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@types/bootstrap/-/bootstrap-5.2.10.tgz",
+      "integrity": "sha512-F2X+cd6551tep0MvVZ6nM8v7XgGN/twpdNDjqS1TUM7YFNEtQYWk+dKAnH+T1gr6QgCoGMPl487xw/9hXooa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@popperjs/core": "^2.9.2"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Provides Shopware Storefront Typescript types",
   "types": "index.d.ts",
+  "scripts": {
+    "test": "tsc --project tsconfig.test.json"
+  },
   "dependencies": {
     "@types/bootstrap": "^5.2.0"
   },

--- a/plugin-system/plugin.d.ts
+++ b/plugin-system/plugin.d.ts
@@ -1,19 +1,19 @@
 import NativeEventEmitter from "./native-event-emitter";
 
-export default interface PluginBaseClass {
-    new(el: HTMLElement, options?: any, pluginName?: false | string): PluginBaseClass;
+export default interface PluginBaseClass<Options extends object = Record<string, unknown>> {
+    new(el: HTMLElement, options?: Partial<Options>, pluginName?: false | string): PluginBaseClass<Options>;
 
     el: HTMLElement;
     $emitter: NativeEventEmitter;
     _pluginName: String;
-    initialOptions: object;
-    options: object;
+    initialOptions: Options;
+    options: Options;
     _initialized: boolean;
     init(): void;
     _update(): void;
     update(): void;
     _registerInstance(): void;
     _getPluginName(pluginName: false | string): String;
-    _mergeOptions(options: any): object;
+    _mergeOptions(options: Partial<Options>): Options;
     parseJsonOrFail(dashedPluginName: string): any | string;
 }

--- a/tests/plugin.test-d.ts
+++ b/tests/plugin.test-d.ts
@@ -1,0 +1,49 @@
+import type PluginBaseClass from '../plugin-system/plugin';
+
+// Test: Generic with custom options type
+interface MyPluginOptions {
+    option1: string;
+    option2: number | null;
+    nested: {
+        value: boolean;
+    };
+}
+
+declare const myPlugin: PluginBaseClass<MyPluginOptions>;
+
+// Test: options should be typed correctly
+const opt1: string = myPlugin.options.option1;
+const opt2: number | null = myPlugin.options.option2;
+const nestedVal: boolean = myPlugin.options.nested.value;
+
+// Test: initialOptions should also be typed
+const initOpt1: string = myPlugin.initialOptions.option1;
+
+// Test: _mergeOptions should accept Partial<Options> and return Options
+const merged: MyPluginOptions = myPlugin._mergeOptions({ option1: 'test' });
+const mergedEmpty: MyPluginOptions = myPlugin._mergeOptions({});
+
+// Test: Default generic (backwards compatibility)
+declare const defaultPlugin: PluginBaseClass;
+
+// Default plugin options should be Record<string, unknown>
+const defaultOpt: unknown = defaultPlugin.options['anyKey'];
+const defaultInitOpt: unknown = defaultPlugin.initialOptions['anyKey'];
+
+// Test: Constructor options parameter should accept Partial<Options>
+declare const PluginClass: PluginBaseClass<MyPluginOptions>;
+declare const element: HTMLElement;
+const instance = new PluginClass(element, { option1: 'partial' });
+const instanceNoOpts = new PluginClass(element);
+
+// @ts-expect-error - Should error when accessing non-existent property on typed options
+myPlugin.options.nonExistent;
+
+// @ts-expect-error - Should error when assigning wrong type
+const wrongType: number = myPlugin.options.option1;
+
+// @ts-expect-error - Should error when passing wrong option type to constructor
+new PluginClass(element, { option1: 123 });
+
+// @ts-expect-error - Should error when passing unknown option to constructor
+new PluginClass(element, { unknownOption: 'value' });

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "DOM"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "include": [
+        "tests/**/*.test-d.ts"
+    ]
+}


### PR DESCRIPTION
This pull request introduces TypeScript type tests for plugin options, adds documentation for using typed plugin options, and sets up automated testing with GitHub Actions. The main changes include new type-level tests, updated documentation, and new configuration files for testing and CI.

**TypeScript Type Testing and Plugin Options:**

* Added comprehensive type-level tests in `tests/plugin.test-d.ts` to ensure `PluginBaseClass` correctly handles generic options, type inference, and type errors.
* Documented how to use generic type parameters for fully typed plugin options in the `README.md`.

**Testing and Continuous Integration Setup:**

* Added a `test` script to `package.json` to run TypeScript tests using a dedicated `tsconfig.test.json` configuration. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R6-R8) [[2]](diffhunk://#diff-e4fb77850197aa340b1f8f426bb0d445c854e20f0a3dd184050ed555fae92713R1-R18)
* Created a GitHub Actions workflow in `.github/workflows/test.yml` to automatically install dependencies and run tests on pushes and pull requests to `main`.