### PR TITLE
Add window.formValidation, validationMessages & useDefaultCookieConsent declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This package provides types for window-bound classes in Shopware 6 Storefront:
 - `window.PluginManager`
 - `window.PluginBaseClass`
 - `window.router`
+- `window.formValidation`
+- `window.validationMessages`
+- `window.useDefaultCookieConsent`
 
 and all regular imports of the Storefront.
 
@@ -46,6 +49,31 @@ export default class MyPlugin extends PluginBaseClass<MyPluginOptions> {
         // this.options is fully typed
         console.log(this.options.option1); // string
         console.log(this.options.option2); // number | null
+    }
+}
+```
+
+## Extending Global Interfaces
+
+The `ShopwareRouter` and `ShopwareValidationMessages` interfaces can be extended via [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) to add custom routes or validation messages from your plugin:
+
+```ts
+// Add custom routes
+declare global {
+    interface ShopwareRouter {
+        'frontend.my-plugin.my-route': string;
+    }
+}
+
+// The route is now available with type safety
+const url = window.router['frontend.my-plugin.my-route'];
+```
+
+```ts
+// Add custom validation messages
+declare global {
+    interface ShopwareValidationMessages {
+        myCustomValidator: string;
     }
 }
 ```

--- a/declare/helper/form-validation.helper.d.ts
+++ b/declare/helper/form-validation.helper.d.ts
@@ -1,0 +1,42 @@
+declare module 'src/helper/form-validation.helper' {
+    interface FormValidationConfig {
+        validClass: string;
+        validFeedbackClass: string;
+        invalidClass: string;
+        invalidFeedbackClass: string;
+        defaultMinLength: number;
+    }
+
+    class FormValidation {
+        static config: FormValidationConfig;
+
+        constructor(config?: Partial<FormValidationConfig>);
+
+        config: FormValidationConfig;
+        errorMessages: Map<string, string>;
+        validators: Map<string, (value: string, field: HTMLElement) => boolean>;
+
+        addValidator(validatorName: string, validationFunction: (value: string, field: HTMLElement) => boolean, errorMessage?: string): boolean;
+        addErrorMessage(validatorName: string, errorMessage: string): boolean;
+        setConfig(key: string, value: any): void;
+        validateForm(form: HTMLFormElement, formFields?: NodeListOf<HTMLElement>): false | HTMLElement[];
+        validateField(field: HTMLElement): false | string[];
+        validateRequired(value: string, field: HTMLElement): boolean;
+        validateEmail(value: string): boolean;
+        validateConfirmation(value: string, field: HTMLElement): boolean;
+        validateMinLength(value: string, field: HTMLElement): boolean;
+        validateGrecaptcha(value: string, field: HTMLElement): boolean;
+        setFieldValid(field: HTMLElement): void;
+        setFieldInvalid(field: HTMLElement, validationErrors: string[]): void;
+        setFieldNeutral(field: HTMLElement): void;
+        setFieldRequired(field: HTMLElement): void;
+        setFieldNotRequired(field: HTMLElement): void;
+        setFieldValidationMessage(field: HTMLElement, validationErrors: string[]): boolean;
+        resetFieldFeedback(field: HTMLElement): boolean;
+        checkVisibility(el: HTMLElement): boolean;
+        setNoValidate(el: HTMLElement): void;
+        isFormElement(el: HTMLElement): boolean;
+    }
+
+    export = FormValidation;
+}

--- a/declare/index.d.ts
+++ b/declare/index.d.ts
@@ -1,6 +1,7 @@
 /// <reference path="plugin-system/plugin.class.d.ts" />
 /// <reference path="plugin-system/plugin.manager.d.ts" />
 
+/// <reference path="helper/form-validation.helper.d.ts" />
 /// <reference path="helper/date.helper.d.ts" />
 /// <reference path="helper/debouncer.helper.d.ts" />
 /// <reference path="helper/device-detection.helper.d.ts" />

--- a/global.d.ts
+++ b/global.d.ts
@@ -15,6 +15,15 @@ declare global {
             'frontend.app-system.generate-token': string,
         }
         bootstrap: typeof import('bootstrap')
+        formValidation: import('./helper/form-validation').default,
+        validationMessages: {
+            required: string,
+            email: string,
+            confirmation: string,
+            minLength: string,
+            grecaptcha: string,
+        }
+        useDefaultCookieConsent?: true
      }
 
     interface Document {

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,5 +1,5 @@
 declare global {
-    interface ValidationMessages {
+    interface ShopwareValidationMessages {
         required: string,
         email: string,
         confirmation: string,
@@ -7,24 +7,26 @@ declare global {
         grecaptcha: string,
     }
 
+    interface ShopwareRouter {
+        'frontend.cart.offcanvas': string,
+        'frontend.cookie.offcanvas': string,
+        'frontend.checkout.finish.page': string,
+        'frontend.checkout.info': string,
+        'frontend.menu.offcanvas': string,
+        'frontend.cms.page': string,
+        'frontend.cms.navigation.page': string,
+        'frontend.account.addressbook': string,
+        'frontend.country.country-data': string,
+        'frontend.app-system.generate-token': string,
+    }
+
     interface Window {
         PluginManager: import('./plugin-system/plugin-manager').default,
         PluginBaseClass: typeof import('./plugin-system/plugin').default,
-        router: {
-            'frontend.cart.offcanvas': string,
-            'frontend.cookie.offcanvas': string,
-            'frontend.checkout.finish.page': string,
-            'frontend.checkout.info': string,
-            'frontend.menu.offcanvas': string,
-            'frontend.cms.page': string,
-            'frontend.cms.navigation.page': string,
-            'frontend.account.addressbook': string,
-            'frontend.country.country-data': string,
-            'frontend.app-system.generate-token': string,
-        }
+        router: ShopwareRouter,
         bootstrap: typeof import('bootstrap')
         formValidation: import('./helper/form-validation').default,
-        validationMessages: ValidationMessages,
+        validationMessages: ShopwareValidationMessages,
         useDefaultCookieConsent?: true
      }
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,4 +1,12 @@
 declare global {
+    interface ValidationMessages {
+        required: string,
+        email: string,
+        confirmation: string,
+        minLength: string,
+        grecaptcha: string,
+    }
+
     interface Window {
         PluginManager: import('./plugin-system/plugin-manager').default,
         PluginBaseClass: typeof import('./plugin-system/plugin').default,
@@ -16,14 +24,7 @@ declare global {
         }
         bootstrap: typeof import('bootstrap')
         formValidation: import('./helper/form-validation').default,
-        validationMessages: {
-            required: string,
-            email: string,
-            confirmation: string,
-            minLength: string,
-            grecaptcha: string,
-            [key: string]: string,
-        }
+        validationMessages: ValidationMessages,
         useDefaultCookieConsent?: true
      }
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -22,6 +22,7 @@ declare global {
             confirmation: string,
             minLength: string,
             grecaptcha: string,
+            [key: string]: string,
         }
         useDefaultCookieConsent?: true
      }

--- a/helper/form-validation.d.ts
+++ b/helper/form-validation.d.ts
@@ -1,0 +1,38 @@
+export interface FormValidationConfig {
+    validClass: string;
+    validFeedbackClass: string;
+    invalidClass: string;
+    invalidFeedbackClass: string;
+    defaultMinLength: number;
+}
+
+export default class FormValidation {
+    static config: FormValidationConfig;
+
+    constructor(config?: Partial<FormValidationConfig>);
+
+    config: FormValidationConfig;
+    errorMessages: Map<string, string>;
+    validators: Map<string, (value: string, field: HTMLElement) => boolean>;
+
+    addValidator(validatorName: string, validationFunction: (value: string, field: HTMLElement) => boolean, errorMessage?: string): boolean;
+    addErrorMessage(validatorName: string, errorMessage: string): boolean;
+    setConfig(key: string, value: any): void;
+    validateForm(form: HTMLFormElement, formFields?: NodeListOf<HTMLElement>): false | HTMLElement[];
+    validateField(field: HTMLElement): false | string[];
+    validateRequired(value: string, field: HTMLElement): boolean;
+    validateEmail(value: string): boolean;
+    validateConfirmation(value: string, field: HTMLElement): boolean;
+    validateMinLength(value: string, field: HTMLElement): boolean;
+    validateGrecaptcha(value: string, field: HTMLElement): boolean;
+    setFieldValid(field: HTMLElement): void;
+    setFieldInvalid(field: HTMLElement, validationErrors: string[]): void;
+    setFieldNeutral(field: HTMLElement): void;
+    setFieldRequired(field: HTMLElement): void;
+    setFieldNotRequired(field: HTMLElement): void;
+    setFieldValidationMessage(field: HTMLElement, validationErrors: string[]): boolean;
+    resetFieldFeedback(field: HTMLElement): boolean;
+    checkVisibility(el: HTMLElement): boolean;
+    setNoValidate(el: HTMLElement): void;
+    isFormElement(el: HTMLElement): boolean;
+}


### PR DESCRIPTION
## Summary
- Adds `window.formValidation` typed as a `FormValidation` instance with all public methods (`validateForm`, `validateField`, `addValidator`, etc.)
- Adds `window.validationMessages` typed as an object with `required`, `email`, `confirmation`, `minLength`, `grecaptcha` string properties
- Adds `window.useDefaultCookieConsent` as an optional boolean (`true | undefined`)
- Adds ambient module declaration for `'src/helper/form-validation.helper'`

Closes #12

## Test plan
- [x] `tsc --project tsconfig.json` passes
- [x] `npm test` (tsconfig.test.json) passes